### PR TITLE
fix: abort on tab change

### DIFF
--- a/src/useStream.tsx
+++ b/src/useStream.tsx
@@ -67,7 +67,7 @@ export function useStream(options: StreamOptions = defaultStreamOptions) {
           source: "user",
         }),
         signal: controller.signal,
-        openWhenHidden: false,
+        openWhenHidden: true,
         onmessage(event) {
           try {
             const parsed: EmittedEvent = JSON.parse(event.data);


### PR DESCRIPTION
fixes the issue where the request is aborted when tab is changed and retried when visible again. (https://github.com/Azure/fetch-event-source/blob/main/src/fetch.ts#L50)